### PR TITLE
Always fetch trakt community ratings if missing locally

### DIFF
--- a/MP-TVSeries/Online Parsing Classes/OnlineParse.cs
+++ b/MP-TVSeries/Online Parsing Classes/OnlineParse.cs
@@ -1920,22 +1920,25 @@ namespace WindowPlugins.GUITVSeries
             // get list of updated shows from trakt
             DateTime dteLastUpdated = DateTime.MinValue;
             string strLastUpdated = DBOption.GetOptions(DBOption.cTraktLastDateUpdated);
-            HashSet<string> recentSeries = new HashSet<string>();
+            var recentSeries = new HashSet<string>();
             IEnumerable<TraktAPI.DataStructures.TraktShowUpdate> updatedShows = null;
 
             // ensure we set the TraktAPI client ID if we are using the configuration tool
             // dont't need to worry about this when running inside MP as it will be initialised by
             // the trakt plugin - we could register an ID for the tvseries plugin
-            if (Settings.isConfig)
+            if ( Settings.isConfig )
             {
-                TraktAPI.TraktAPI.ClientId = "49e6907e6221d3c7e866f9d4d890c6755590cf4aa92163e8490a17753b905e57";
-                using (MediaPortal.Profile.Settings xmlreader = new MediaPortal.Profile.MPSettings())
-                {
-                    // this should not be required but for some reason trakt is complaining.
-                    TraktAPI.TraktAPI.UserAccessToken = xmlreader.GetValueAsString("Trakt", "UserAccessToken", "");
-                }
+              TraktAPI.TraktAPI.ClientId = "";
+              using ( MediaPortal.Profile.Settings xmlreader = new MediaPortal.Profile.MPSettings() )
+              {
+                // this should not be required but for some reason trakt is complaining.
+                TraktAPI.TraktAPI.UserAccessToken = xmlreader.GetValueAsString( "Trakt", "UserAccessToken", "" );
+              }
+              // TODO: determine best way to handle this for the configuration tool
+              // the trakt plugin client id is currently "internal" so needs to change that or we need to register a client id for the tvseries plugin
+              return;
             }
- 
+
             #region Recently Updated Shows
             if (!string.IsNullOrEmpty(strLastUpdated) && !forceUpdate)
             {
@@ -1982,6 +1985,8 @@ namespace WindowPlugins.GUITVSeries
                 string tvdbId = series[DBSeries.cID];
                 string traktid = series[DBOnlineSeries.cTraktID];
                 string seriesName = series[DBOnlineSeries.cPrettyName];
+                
+                bool hasRating = !string.IsNullOrEmpty(series[DBOnlineSeries.cRating].ToString()) && series[DBOnlineSeries.cRating] != "0";
 
                 #region Trakt ID Lookup
                 if (string.IsNullOrEmpty(traktid))
@@ -2018,36 +2023,36 @@ namespace WindowPlugins.GUITVSeries
                     series.Commit();
                 }
                 #endregion
-                
+
                 #region Series Community Ratings
 
                 #region Update Check
                 // only update ratings for series if it is a series that has recently been updated on trakt.
                 // we don't want to update every series and underlying episode every sync!!!
                 // skip update check on a series if it was recently added
-                if (updatedShows != null && !recentSeries.Contains(tvdbId))
+                if ( updatedShows != null && !recentSeries.Contains( tvdbId ) )
                 {
-                    // if the series hasn't been updated recently continue on to next
-                    var updatedShow = updatedShows.FirstOrDefault(u => u.Show.Ids.Trakt.ToString() == traktid);
+                  // if the series hasn't been updated recently continue on to next
+                  // only if we already have a rating stored in the DB
+                  var updatedShow = updatedShows.FirstOrDefault( u => u.Show.Ids.Trakt.ToString() == traktid );
 
-                    if (updatedShow == null)
+                  if ( updatedShow == null && hasRating )
+                  {
+                    MPTVSeriesLog.Write( string.Format( "Skipping community ratings update for series, the series has not been found in the update list. Title = '{0}', TVDb ID = '{1}', Trakt ID = '{2}'", seriesName, tvdbId, traktid ), MPTVSeriesLog.LogLevel.Debug );
+                    continue;
+                  }
+                  else if ( hasRating )
+                  {
+                    // check that the show updated_at is newer than last time we did an update
+                    if ( DateTime.TryParse( updatedShow?.UpdatedAt, out DateTime dteShowUpdated ) )
                     {
-                        MPTVSeriesLog.Write(string.Format("Skipping community ratings update for series, the series has not been found in the update list. Title = '{0}', TVDb ID = '{1}', Trakt ID = '{2}'", seriesName, tvdbId, traktid), MPTVSeriesLog.LogLevel.Debug);
+                      if ( dteShowUpdated.ToUniversalTime() < dteLastUpdated.ToUniversalTime() )
+                      {
+                        MPTVSeriesLog.Write( string.Format( "Skipping community ratings update for series, the series has not been updated recently. Title = '{0}', TVDb ID = '{1}', Trakt ID = '{2}', Local Update Time = '{3}', Online Update Time = '{4}'", seriesName, tvdbId, traktid, dteLastUpdated, dteShowUpdated ), MPTVSeriesLog.LogLevel.Debug );
                         continue;
+                      }
                     }
-                    else
-                    {
-                        // check that the show updated_at is newer than last time we did an update
-                        DateTime dteShowUpdated;
-                        if (DateTime.TryParse(updatedShow.UpdatedAt, out dteShowUpdated))
-                        {
-                            if (dteShowUpdated.ToUniversalTime() < dteLastUpdated.ToUniversalTime())
-                            {
-                                MPTVSeriesLog.Write(string.Format("Skipping community ratings update for series, the series has not been updated recently. Title = '{0}', TVDb ID = '{1}', Trakt ID = '{2}', Local Update Time = '{3}', Online Update Time = '{4}'", seriesName, tvdbId, traktid, dteLastUpdated, DateTime.Parse(updatedShow.UpdatedAt)), MPTVSeriesLog.LogLevel.Debug);
-                                continue;
-                            }
-                        }
-                    }
+                  }
                 }
                 #endregion
 

--- a/MPEI/MP-TVSeries.xmp2
+++ b/MPEI/MP-TVSeries.xmp2
@@ -1754,11 +1754,11 @@ public class Script
 
 
 The MP-TVSeries plugin will scan your hard drive (including network and removable drives) for video files, it then analyzes them by their path structures to determine if they are TV Shows. If the file(s) are recognized then the plugin will go online and retrieve information about them. You can then browse, manage and play your episodes from inside MediaPortal in a nice graphical layout.</ExtensionDescription>
-    <VersionDescription>* Added string replacement rule for x265 (Same as x264 to avoid episode number parsing issues)
+    <VersionDescription>* Always fetch trakt community ratings if missing locally
 </VersionDescription>
     <DevelopmentStatus>Stable</DevelopmentStatus>
     <OnlineLocation>https://github.com/Mediaportal-Plugin-Team/mptvseries/releases/download/v[Version]/MP-TVSeries-[Version].mpe1</OnlineLocation>
-    <ReleaseDate>2026-04-06T15:15:15</ReleaseDate>
+    <ReleaseDate>2026-05-02T15:15:15</ReleaseDate>
     <Tags>tvseries,tv,mp-tvseries,videos,thetvdb</Tags>
     <PlatformCompatibility>AnyCPU</PlatformCompatibility>
     <Location>.\Release\[Name]-[Version].mpe1</Location>


### PR DESCRIPTION
TODO: right now ratings from trakt wont work from the Config tool so I have disabled that. It will only work when running MediaPortal GUI.